### PR TITLE
Adding Windows driver and exe code for monitoring established network flows

### DIFF
--- a/windows/exe/monitor.cpp
+++ b/windows/exe/monitor.cpp
@@ -1,0 +1,148 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved
+
+Abstract:
+
+    Monitor executable
+
+Environment:
+
+    User mode
+    
+--*/
+
+#include "windows.h"
+#include "winioctl.h"
+#include "strsafe.h"
+
+#ifndef _CTYPE_DISABLE_MACROS
+#define _CTYPE_DISABLE_MACROS
+#endif
+
+#include "ws2def.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ioctl.h"
+
+VOID
+PrintIP(UINT32 ip)
+{
+	UCHAR bytes[4];
+	bytes[3] = ip & 0xFF;
+	bytes[2] = (ip >> 8) & 0xFF;
+	bytes[1] = (ip >> 16) & 0xFF;
+	bytes[0] = (ip >> 24) & 0xFF;
+	printf("%u.%u.%u.%u", bytes[3], bytes[2], bytes[1], bytes[0]);
+}
+
+int
+PrintFlow(DDPROXY_FLOW* Flow)
+{
+	SYSTEMTIME st;
+
+	if (Flow->protocol == 0) {
+		return 0;
+	}
+
+	GetSystemTime(&st);
+
+	printf("{ \"@timestamp\" : \"%d-%02d-%02dT%02d:%02d:%02d\", ", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+	printf("\"ct.event\" : 1 ,");
+	printf("\"src_ip\" : \"");
+	PrintIP(Flow->ipv4Local);
+	printf("\", \"dest_ip\" : \"");
+	PrintIP(Flow->ipv4Remote);
+	printf("\", \"orig.l4.sport\": %u, \"orig.l4.dport\": %u, \"orig.ip.protocol\": %u }", 
+		Flow->portLocal, Flow->portRemote, Flow->protocol);
+	return 1;
+}
+
+DWORD
+StartMonitoring()
+{
+	UINT32 flowCount = 20;
+	DWORD bytesReturned;
+	int BufferSz = FIELD_OFFSET(DDPROXY_FLOWS, Flow[flowCount]);
+	DDPROXY_FLOWS* flows = (DDPROXY_FLOWS*) malloc(BufferSz);
+	DDPROXY_FLOWS* inflows = (DDPROXY_FLOWS*) malloc(BufferSz);
+	UINT32 flowIndex = 0;
+	flows->NumberOfFlows = flowCount;
+	inflows->NumberOfFlows = flowCount;
+	DDPROXY_FLOW* flow = NULL;
+	int p = 0;
+
+
+    HANDLE h = CreateFileW(DDPROXY_DOS_NAME,
+                                 GENERIC_READ, 
+                                 FILE_SHARE_READ, 
+                                 NULL, 
+                                 OPEN_EXISTING, 
+                                 0, 
+                                 NULL);
+
+    if (h == INVALID_HANDLE_VALUE)
+    {
+		printf("could not get handle\n");
+        return GetLastError();
+    }
+
+	for (flowIndex = 0; flowIndex < flowCount; flowIndex++) {
+		flow = &flows->Flow[flowIndex];
+		flow->ipv4Local = 0;
+		flow->ipv4Remote = 0;
+		flow->portLocal = 0;
+		flow->portRemote = 0;
+		flow->protocol = 0;
+	}
+
+	if (!DeviceIoControl(h, DDPROXY_IOCTL_GET_CONNECTIONS,
+		inflows, BufferSz, flows, BufferSz, &bytesReturned, NULL))
+	{
+		printf("ioctl failed\n");
+		return GetLastError();
+	}
+	// printf("flow count: %d\n", flows->NumberOfFlows);
+	// printf("[\n");
+	for (flowIndex = 0; flowIndex < flowCount - 1; flowIndex++) {
+		flow = &flows->Flow[flowIndex];
+		p = PrintFlow(flow);
+		if (p == 1) {
+			printf("\n");
+		}
+	}
+	flow = &flows->Flow[flowIndex];
+	PrintFlow(flow);
+	//printf("\n]\n");
+
+	CloseHandle(h);
+    return NO_ERROR;
+}
+
+BOOL MonitorAppCloseMonitorDevice(
+   _In_ HANDLE monitorDevice)
+{
+    return CloseHandle(monitorDevice);
+}
+
+
+int __cdecl wmain(_In_ int argc, _In_reads_(argc) PCWSTR argv[])
+{
+   UNREFERENCED_PARAMETER(argc);
+   UNREFERENCED_PARAMETER(argv);
+   DWORD err = NO_ERROR;
+   //printf("Starting to Monitor ..\n");
+
+   err = StartMonitoring();
+   //printf("err: %d \n", err);
+   if (err != NO_ERROR) {
+	   printf("Failed to monitor. Error: %d \n", err);
+	   goto Exit;
+   }
+
+   //printf("Monitoring started\n");
+Exit:
+   return (int) err;
+}

--- a/windows/exe/monitor.vcxproj
+++ b/windows/exe/monitor.vcxproj
@@ -1,0 +1,202 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A775BC8D-48D4-4332-B731-6135FDD0C94A}</ProjectGuid>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <SampleGuid>{2142A4F7-2EDA-43A2-AA9B-237435A8B04E}</SampleGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType />
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType />
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType />
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+    <DriverType />
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>$(IntDir)</OutDir>
+  </PropertyGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ItemGroup Label="WrappedTaskItems" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>monitor</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>monitor</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>monitor</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>monitor</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <UseOfAtl>Static</UseOfAtl>
+    <NTDDI_VERSION>NTDDI_WIN7</NTDDI_VERSION>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseOfAtl>Static</UseOfAtl>
+    <NTDDI_VERSION>NTDDI_WIN7</NTDDI_VERSION>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <UseOfAtl>Static</UseOfAtl>
+    <NTDDI_VERSION>NTDDI_WIN7</NTDDI_VERSION>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseOfAtl>Static</UseOfAtl>
+    <NTDDI_VERSION>NTDDI_WIN7</NTDDI_VERSION>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);advapi32.lib;comctl32.lib;kernel32.lib;netapi32.lib;ole32.lib;oleaut32.lib;user32.lib;uuid.lib;ntdll.lib;kernel32.lib;setupapi.lib;rpcrt4.lib;fwpuclnt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);advapi32.lib;comctl32.lib;kernel32.lib;netapi32.lib;ole32.lib;oleaut32.lib;user32.lib;uuid.lib;ntdll.lib;kernel32.lib;setupapi.lib;rpcrt4.lib;fwpuclnt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);advapi32.lib;comctl32.lib;kernel32.lib;netapi32.lib;ole32.lib;oleaut32.lib;user32.lib;uuid.lib;ntdll.lib;kernel32.lib;setupapi.lib;rpcrt4.lib;fwpuclnt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SDK_INC_PATH);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);advapi32.lib;comctl32.lib;kernel32.lib;netapi32.lib;ole32.lib;oleaut32.lib;user32.lib;uuid.lib;ntdll.lib;kernel32.lib;setupapi.lib;rpcrt4.lib;fwpuclnt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="monitor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Exclude="@(Inf)" Include="*.inf" />
+    <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
+    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
+    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/windows/exe/monitor.vcxproj.Filters
+++ b/windows/exe/monitor.vcxproj.Filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx;*</Extensions>
+      <UniqueIdentifier>{23749ED7-3361-4C55-BC65-7FEB41F22410}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+      <UniqueIdentifier>{514D9180-B3CA-48A3-A0A1-6E1693F852C4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms;man;xml</Extensions>
+      <UniqueIdentifier>{DB4C51F6-0F6E-404E-9F69-06769044B4B1}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="monitor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/windows/exe/mtrace.cmd
+++ b/windows/exe/mtrace.cmd
@@ -1,0 +1,288 @@
+@echo off
+@setlocal
+
+@rem -------------------------------------------------------------------------
+@rem OBTAIN INPUT
+@rem -------------------------------------------------------------------------
+
+set TR_MODULE=%1
+shift
+set TR_LEVEL=%1
+shift
+set TR_VERB=%1
+
+@rem -------------------------------------------------------------------------
+@rem VALIDATE COMPONENT & TRACING LEVEL
+@rem -------------------------------------------------------------------------
+
+if /i "%TR_MODULE%"=="MONITOR" (
+   set TR_GUID={dd65554d-9925-49d1-83b6-46125feb4207}
+   set TR_MODULE=MsnMntrMonitor
+
+   if "%TR_LEVEL%"=="0" (
+      set TR_BITS=
+      set TR_LEVEL=0
+   ) else if "%TR_LEVEL%"=="1" (
+      set TR_BITS=
+      set TR_LEVEL=1
+   ) else if /i "%TR_LEVEL%"=="2" (
+      set TR_BITS=
+      set TR_LEVEL=2
+   ) else if /i "%TR_LEVEL%"=="9" (
+      set TR_BITS=
+      set TR_LEVEL=9
+   ) else (
+      echo.
+      echo Error: Monitor component does not support this trace detail.
+      goto :show_usage_MsnMntrMonitor
+   )
+) else if /i "%TR_MODULE%"=="NOTIFY" (
+   set TR_GUID={aca2f74a-7a0d-4f47-be4b-66900813b8e5}
+   set TR_MODULE=MsnMntrNotify
+
+   if "%TR_LEVEL%"=="0" (
+      set TR_BITS=
+      set TR_LEVEL=0
+   ) else if "%TR_LEVEL%"=="1" (
+      set TR_BITS=
+      set TR_LEVEL=1
+   ) else if /i "%TR_LEVEL%"=="2" (
+      set TR_BITS=
+      set TR_LEVEL=2
+   ) else if /i "%TR_LEVEL%"=="3" (
+      set TR_BITS=
+      set TR_LEVEL=3
+   ) else if /i "%TR_LEVEL%"=="9" (
+      set TR_BITS=
+      set TR_LEVEL=9
+   ) else (
+      echo.
+      echo Error: Notify component does not support this trace detail.
+      goto :show_usage_MsnMntrNotify
+   )   
+   
+) else if /i "%TR_MODULE%"=="CONTROL" (
+   set TR_GUID={eab718af-52de-477c-874d-cb49746bb131}
+   set TR_MODULE=MsnMntrCtl
+
+   if "%TR_LEVEL%"=="0" (
+      set TR_BITS=
+      set TR_LEVEL=0
+   ) else if "%TR_LEVEL%"=="1" (
+      set TR_BITS=
+      set TR_LEVEL=1
+   ) else if /i "%TR_LEVEL%"=="2" (
+      set TR_BITS=
+      set TR_LEVEL=2
+   ) else if /i "%TR_LEVEL%"=="9" (
+      set TR_BITS=
+      set TR_LEVEL=9
+   ) else (
+      echo.
+      echo Error: Control component does not support this trace detail.
+      goto :show_usage_MsnMntrCtl
+   )
+
+) else if /i "%TR_MODULE%"=="INIT" (
+   set TR_GUID={e7db16bb-41be-4c05-b73e-5feca06f8207}
+   set TR_MODULE=MsnMntrInit
+
+   if "%TR_LEVEL%"=="0" (
+      set TR_BITS=
+      set TR_LEVEL=0
+   ) else if "%TR_LEVEL%"=="1" (
+      set TR_BITS=
+      set TR_LEVEL=1
+   ) else if /i "%TR_LEVEL%"=="9" (
+      set TR_BITS=
+      set TR_LEVEL=9
+   ) else (
+      echo.
+      echo Error: Init component does not support this trace detail.
+      goto :show_usage_MsnMntrInit
+   )  
+
+) else (
+   echo.
+   echo Error: No module was selected.
+   goto :show_usage
+)
+
+set TR_NAME=%TR_MODULE%
+set TR_DIR=%SystemRoot%\Tracing\%TR_NAME%
+set TR_LOG=%TR_DIR%\%TR_NAME%.etl
+set TR_BITS=0xFFFFFFFF
+set TR_OPTS=
+set TR_RT_OPTS=-rt -ft 1
+
+set TRACE_FORMAT_PREFIX=%%9!d!:%%3!04X! %%!FUNC!:
+set TRACE_FORMAT_SEARCH_PATH=%TR_DIR%
+
+@rem -------------------------------------------------------------------------
+@rem VALIDATE VERB
+@rem -------------------------------------------------------------------------
+
+if /i "%TR_VERB%"=="start" (
+   call :start_trace
+) else if /i "%TR_VERB%"=="stop" (
+   call :stop_trace
+) else if /i "%TR_VERB%"=="pdb" (
+   call :extract_format_info %1
+) else if /i "%TR_VERB%"=="rt" (
+   call :format_realtime
+) else if /i "%TR_VERB%"=="fmt" (
+   call :format_offline
+) else (
+      echo.
+      echo Error: A supported verb has not been specified.
+      goto :show_usage
+)
+
+goto :eof
+
+:ShowSummary
+   echo.
+   echo      Trace name : %TR_NAME%
+   echo Trace directory : %TR_DIR%
+   echo       Trace log : %TR_LOG%
+   echo     Trace level : %TR_LEVEL%
+
+@rem -------------------------------------------------------------------------
+@rem START TRACING
+@rem -------------------------------------------------------------------------
+:start_trace
+   if not exist %TR_DIR% mkdir %TR_DIR%
+   logman query %TR_NAME% -ets 1 > NUL
+   if errorlevel 1 (
+      logman start %TR_NAME% %TR_OPTS% -p %TR_GUID% %TR_BITS% %TR_LEVEL% -o %TR_LOG% -ets
+   ) else (
+      echo Collection is already started.
+      )
+   goto :eof
+
+@rem -------------------------------------------------------------------------
+@rem STOP TRACING
+@rem -------------------------------------------------------------------------
+:stop_trace
+   logman query %TR_NAME% -ets 1>NUL
+   if NOT errorlevel 1 (
+      logman stop %TR_NAME% -ets
+   )
+   goto :eof
+
+@rem -------------------------------------------------------------------------
+@rem EXTRACT FORMAT INFO
+@rem -------------------------------------------------------------------------
+:extract_format_info
+   if "%1" == "" (
+      set TR_PDB=.\%TR_MODULE%.pdb
+   )else (
+      set TR_PDB=%1
+   )
+   tracepdb -f %TR_PDB% -p %TR_DIR%
+   goto :eof
+
+@rem -------------------------------------------------------------------------
+@rem FORMAT REALTIME
+@rem -------------------------------------------------------------------------
+:format_realtime
+   call :stop_trace
+   set TR_OPTS=%TR_RT_OPTS%
+   call :start_trace
+   start "%TR_NAME% Tracing" /low tracefmt -displayonly -rt %TR_NAME%
+   goto :eof
+
+@rem -------------------------------------------------------------------------
+@rem FORMAT OFFLINE
+@rem -------------------------------------------------------------------------
+:format_offline
+   tracefmt -o %TR_NAME%.txt %TR_LOG% -display
+   goto :eof
+
+goto :eof
+
+@rem -------------------------------------------------------------------------
+@rem CONTEXT SENSITIVE HELP
+@rem -------------------------------------------------------------------------
+:show_usage
+   call :show_usage_header
+   echo    9   Display all trace events
+   echo        Select a component to see individual supported tracing levels.
+   call :show_usage_footer
+   
+   goto :eof
+
+:show_usage_MsnMntrMonitor
+   call :show_usage_header
+   echo    0   Established flow
+   echo    1   Change of state information
+   echo    2   Layer notifications
+   echo    9   Display all trace events
+   call :show_usage_footer
+   
+   goto :eof
+
+:show_usage_MsnMntrNotify
+   call :show_usage_header
+   echo    0   Client to server
+   echo    1   Peer to peer
+   echo    2   Unknown
+   echo    3   All traffic
+   echo    9   Display all trace events
+   call :show_usage_footer
+
+   goto :eof
+   
+:show_usage_MsnMntrCtl
+   call :show_usage_header
+   echo    0   Initialization
+   echo    1   Device control
+   echo    2   State
+   echo    9   Display all trace events
+   call :show_usage_footer
+
+   goto :eof
+   
+:show_usage_MsnMntrInit
+   call :show_usage_header
+   echo    0   Initialization
+   echo    1   Shutdown
+   echo    9   Display all trace events
+   call :show_usage_footer
+
+   goto :eof
+   
+:show_usage_header
+   echo.
+   echo Usage: monitor_trace COMPONENT LEVEL VERB
+   echo.
+   echo Components: 
+   echo    MONITOR, NOTIFY, CONTROL and INIT
+   echo.
+   echo Trace detail:
+   goto :eof
+
+:show_usage_footer
+   echo.
+   echo Verbs:
+   echo    start        Start collection.
+   echo    stop         Stop collection.
+   echo    pdb          Extract format information from the pdb in the current
+   echo                 directory.
+   echo    pdb [file]   Like the above, but allows the full path to the pdb
+   echo                 to be specified.
+   echo    rt           Displays the trace output in real-time. This
+   echo                 automatically stops any existing collection and begins
+   echo                 a new one with appropriate parameters for real-time.
+   echo    fmt          Format the trace logfile to the console.
+   echo.
+   echo Note:
+   echo    The most common scenario is to extract the format information from
+   echo    the pdb, and then display the output in real-time.
+   echo.
+   echo Example:
+   echo    cd /d MySymbolDir
+   echo    monitor_trace init 0 pdb
+   echo    monitor_trace init 0 rt
+
+   goto :eof

--- a/windows/inc/ioctl.h
+++ b/windows/inc/ioctl.h
@@ -1,0 +1,37 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved
+
+Abstract:
+
+    ddproxy IOCTL header
+
+Environment:
+
+    Kernel mode
+    
+--*/
+
+#pragma once
+
+#define DDPROXY_DEVICE_NAME     L"\\Device\\DDProxy"
+#define DDPROXY_SYMBOLIC_NAME   L"\\DosDevices\\Global\\DDProxy"
+#define DDPROXY_DOS_NAME   L"\\\\.\\DDProxy"
+
+typedef struct _DDPROXY_FLOW
+{
+	UINT32  ipv4Remote;
+	UINT16  portRemote;
+	UINT32  ipv4Local;
+	UINT16  portLocal;
+	UINT32  protocol;
+} DDPROXY_FLOW;
+
+typedef struct _DDPROXY_FLOWS
+{
+	UINT32                  NumberOfFlows;
+	DDPROXY_FLOW            Flow[1];
+} DDPROXY_FLOWS;
+
+#define	DDPROXY_IOCTL_GET_CONNECTIONS  CTL_CODE(FILE_DEVICE_NETWORK, 0x1, METHOD_BUFFERED, FILE_ANY_ACCESS)
+

--- a/windows/sys/DD_drv.c
+++ b/windows/sys/DD_drv.c
@@ -1,0 +1,518 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved
+
+Abstract:
+
+   Connection tracking filter.
+
+Environment:
+
+    Kernel mode
+
+--*/
+
+#include <ntddk.h>
+#include <wdf.h>
+
+#pragma warning(push)
+#pragma warning(disable:4201)
+
+#include <fwpsk.h>
+
+#pragma warning(pop)
+
+#include <fwpmk.h>
+
+#include <ws2ipdef.h>
+#include <in6addr.h>
+#include <ip2string.h>
+
+#include "DD_proxy.h"
+#include "ioctl.h"
+
+#define INITGUID
+#include <guiddef.h>
+
+// Callout and sublayer GUIDs
+
+// ee93719d-ad5d-48c9-ae46-7270367d205d
+DEFINE_GUID(
+    DD_PROXY_FLOW_ESTABLISHED_CALLOUT_V4,
+    0xee93719d,
+    0xad5d,
+    0x48c9,
+    0xae, 0x46, 0x72, 0x70, 0x36, 0x7d, 0x20, 0x5d
+);
+
+
+// 0104fd7e-c825-414e-94c9-f0d525bbc169
+DEFINE_GUID(
+    DD_PROXY_SUBLAYER,
+    0x0104fd7e,
+    0xc825,
+    0x414e,
+    0x94, 0xc9, 0xf0, 0xd5, 0x25, 0xbb, 0xc1, 0x69
+);
+
+
+// Callout driver global variables
+
+DEVICE_OBJECT* gWdmDevice;
+
+HANDLE gEngineHandle;
+UINT32 gFlowEstablishedCalloutIdV4, gCalloutIdV4;
+UINT32 gFlowEstablishedCalloutIdV6, gCalloutIdV6;
+
+HANDLE gInjectionHandle;
+
+LIST_ENTRY gFlowList;
+KSPIN_LOCK gFlowListLock;
+
+LIST_ENTRY gPacketQueue;
+KSPIN_LOCK gPacketQueueLock;
+KEVENT gPacketQueueEvent;
+
+BOOLEAN gDriverUnloading = FALSE;
+void* gThreadObj;
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_UNLOAD EvtDriverUnload;
+
+
+// Callout driver implementation
+
+NTSTATUS
+DDProxyRegisterFlowEstablishedCallouts(
+   _In_ const GUID* layerKey,
+   _In_ const GUID* calloutKey,
+   _Inout_ void* deviceObject,
+   _Out_ UINT32* calloutId
+   )
+{
+   NTSTATUS status = STATUS_SUCCESS;
+
+   FWPS_CALLOUT sCallout = {0};
+   FWPM_CALLOUT mCallout = {0};
+   FWPM_FILTER filter =    {0};
+
+   FWPM_DISPLAY_DATA displayData = {0};
+   BOOLEAN calloutRegistered = FALSE;
+
+   sCallout.calloutKey = *calloutKey;
+   sCallout.classifyFn = DDProxyFlowEstablishedClassify;
+   sCallout.notifyFn = DDProxyFlowEstablishedNotify;
+
+   status = FwpsCalloutRegister(
+               deviceObject,
+               &sCallout,
+               calloutId
+               );
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+   calloutRegistered = TRUE;
+
+   displayData.name = L"Datagram-Data Proxy Flow-Established Callout";
+   displayData.description = L"Intercepts flow creations";
+
+   mCallout.calloutKey = *calloutKey;
+   mCallout.displayData = displayData;
+   mCallout.applicableLayer = *layerKey;
+
+   status = FwpmCalloutAdd(
+	   gEngineHandle,
+	   &mCallout,
+	   NULL,
+	   NULL
+   );
+
+   filter.layerKey = *layerKey;
+   filter.displayData.name = L"Flow-Established Filter";
+   filter.displayData.description = L"Filter to record flows";
+
+   filter.action.type = FWP_ACTION_CALLOUT_TERMINATING;
+   filter.action.calloutKey = *calloutKey;
+   filter.numFilterConditions = 0;
+   filter.subLayerKey = DD_PROXY_SUBLAYER;
+   filter.weight.type = FWP_EMPTY; // auto-weight.
+
+   status = FwpmFilterAdd(
+	   gEngineHandle,
+	   &filter,
+	   NULL,
+	   NULL);
+
+   if (!NT_SUCCESS(status))
+   {
+	   goto Exit;
+   }
+
+
+Exit:
+
+   if (!NT_SUCCESS(status))
+   {
+      if (calloutRegistered)
+      {
+         FwpsCalloutUnregisterById(*calloutId);
+         *calloutId = 0;
+      }
+   }
+
+   return status;
+}
+
+
+NTSTATUS
+DDProxyRegisterCallouts(
+   _Inout_ void* deviceObject
+   )
+{
+   NTSTATUS status = STATUS_SUCCESS;
+   FWPM_SUBLAYER DDProxySubLayer;
+
+   BOOLEAN engineOpened = FALSE;
+   BOOLEAN inTransaction = FALSE;
+
+   FWPM_SESSION session = {0};
+
+   session.flags = FWPM_SESSION_FLAG_DYNAMIC;
+
+   status = FwpmEngineOpen(
+                NULL,
+                RPC_C_AUTHN_WINNT,
+                NULL,
+                &session,
+                &gEngineHandle
+                );
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+   engineOpened = TRUE;
+
+   status = FwpmTransactionBegin(gEngineHandle, 0);
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+   inTransaction = TRUE;
+
+   RtlZeroMemory(&DDProxySubLayer, sizeof(FWPM_SUBLAYER)); 
+
+   DDProxySubLayer.subLayerKey = DD_PROXY_SUBLAYER;
+   DDProxySubLayer.displayData.name = L"Datagram-Data Proxy Sub-Layer";
+   DDProxySubLayer.displayData.description = 
+      L"Sub-Layer for use by Datagram-Data Proxy callouts";
+   DDProxySubLayer.flags = 0;
+   DDProxySubLayer.weight = FWP_EMPTY; // auto-weight.;
+
+   status = FwpmSubLayerAdd(gEngineHandle, &DDProxySubLayer, NULL);
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+
+   status = DDProxyRegisterFlowEstablishedCallouts(
+               &FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4,
+               &DD_PROXY_FLOW_ESTABLISHED_CALLOUT_V4,
+               deviceObject,
+               &gFlowEstablishedCalloutIdV4
+               );
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+
+   status = FwpmTransactionCommit(gEngineHandle);
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+   inTransaction = FALSE;
+
+Exit:
+
+   if (!NT_SUCCESS(status))
+   {
+      if (inTransaction)
+      {
+         FwpmTransactionAbort(gEngineHandle);
+         _Analysis_assume_lock_not_held_(gEngineHandle); // Potential leak if "FwpmTransactionAbort" fails
+      }
+      if (engineOpened)
+      {
+         FwpmEngineClose(gEngineHandle);
+         gEngineHandle = NULL;
+      }
+   }
+
+   return status;
+}
+
+void
+DDProxyUnregisterCallouts(void)
+{
+   FwpmEngineClose(gEngineHandle);
+   gEngineHandle = NULL;
+
+   FwpsCalloutUnregisterById(gFlowEstablishedCalloutIdV4);
+}
+
+_Function_class_(EVT_WDF_DRIVER_UNLOAD)
+_IRQL_requires_same_
+_IRQL_requires_max_(PASSIVE_LEVEL)
+void
+EvtDriverUnload(
+   _In_ WDFDRIVER driverObject
+   )
+{
+   KLOCK_QUEUE_HANDLE flowListLockHandle;
+
+   UNREFERENCED_PARAMETER(driverObject);
+
+   KeAcquireInStackQueuedSpinLock(
+      &gFlowListLock,
+      &flowListLockHandle
+      );
+
+   gDriverUnloading = TRUE;
+
+   while (!IsListEmpty(&gFlowList))
+   {
+	   PLIST_ENTRY Entry = RemoveHeadList(&gFlowList);
+	   DD_PROXY_FLOW_INFO* flow = CONTAINING_RECORD(Entry, DD_PROXY_FLOW_INFO, listEntry);
+	   ExFreePoolWithTag(flow, DD_PROXY_FLOW_CONTEXT_POOL_TAG);
+   }
+
+   KeReleaseInStackQueuedSpinLock(&flowListLockHandle);
+
+   DDProxyUnregisterCallouts();
+
+   FwpsInjectionHandleDestroy(gInjectionHandle);
+}
+
+
+VOID
+DDProxyDeviceControl(
+	_In_ WDFQUEUE Queue,
+	_In_ WDFREQUEST Request,
+	_In_ size_t OutputBufferLength,
+	_In_ size_t InputBufferLength,
+	_In_ ULONG IoControlCode
+)
+{
+	KLOCK_QUEUE_HANDLE flowListLockHandle;
+	NTSTATUS status = STATUS_SUCCESS;
+	BOOLEAN locked = FALSE;
+	UINT32 count = 0;
+	DDPROXY_FLOWS* flows = NULL;
+	UINT32 sz = 0;
+
+	UNREFERENCED_PARAMETER(Queue);
+	UNREFERENCED_PARAMETER(OutputBufferLength);
+
+	switch (IoControlCode)
+	{
+	case DDPROXY_IOCTL_GET_CONNECTIONS:
+	{
+		void* pBuffer;
+
+		if (InputBufferLength < sizeof(DDPROXY_FLOWS))
+		{
+			status = STATUS_INVALID_PARAMETER;
+		}
+		else
+		{
+			KeAcquireInStackQueuedSpinLock(
+				&gFlowListLock,
+				&flowListLockHandle
+			);
+			locked = TRUE;
+			status = WdfRequestRetrieveOutputBuffer(Request, sizeof(DDPROXY_FLOWS), &pBuffer, NULL);
+			if (NT_SUCCESS(status))
+			{
+				flows = (DDPROXY_FLOWS*) pBuffer;
+				while (!IsListEmpty(&gFlowList) && (count < 10))
+				{
+					PLIST_ENTRY Entry = RemoveHeadList(&gFlowList);
+					DD_PROXY_FLOW_INFO* flow = CONTAINING_RECORD(Entry, DD_PROXY_FLOW_INFO, listEntry);
+					flows->Flow[count].ipv4Remote = flow->ipv4RemoteAddr;
+					flows->Flow[count].ipv4Local  = flow->ipv4LocalAddr;
+					flows->Flow[count].portLocal  = flow->portLocal;
+					flows->Flow[count].portRemote = flow->portRemote;
+					flows->Flow[count].protocol   = flow->protocol;
+					ExFreePoolWithTag(flow, DD_PROXY_FLOW_CONTEXT_POOL_TAG);
+					count++;
+				}
+				flows->NumberOfFlows = count;
+				status = STATUS_SUCCESS;
+				sz = FIELD_OFFSET(DDPROXY_FLOWS, Flow[flows->NumberOfFlows]);
+			}
+
+			
+		}
+		break;
+	}
+
+	default:
+	{
+		status = STATUS_INVALID_PARAMETER;
+	}
+	}
+
+	WdfRequestCompleteWithInformation(Request, status, sz);
+
+	if (locked)
+	{
+		KeReleaseInStackQueuedSpinLock(&flowListLockHandle);
+	}
+}
+
+NTSTATUS
+DDProxyCtlDriverInit(
+	_In_ WDFDEVICE* pDevice
+)
+{
+	NTSTATUS status;
+	WDF_IO_QUEUE_CONFIG queueConfig;
+
+	WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchSequential);
+	queueConfig.EvtIoDeviceControl = DDProxyDeviceControl;
+	status = WdfIoQueueCreate(*pDevice, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, NULL);
+
+	return status;
+}
+
+
+//
+// Create the minimal WDF Driver and Device objects required for a WFP callout
+// driver.
+//
+NTSTATUS
+DDProxyInitDriverObjects(
+   _Inout_ DRIVER_OBJECT* driverObject,
+   _In_ const UNICODE_STRING* registryPath,
+   _Out_ WDFDRIVER* pDriver,
+   _Out_ WDFDEVICE* pDevice
+   )
+{
+   NTSTATUS status;
+   DECLARE_CONST_UNICODE_STRING(ntDeviceName, DDPROXY_DEVICE_NAME);
+   DECLARE_CONST_UNICODE_STRING(symbolicName, DDPROXY_SYMBOLIC_NAME);
+   WDF_DRIVER_CONFIG config;
+   PWDFDEVICE_INIT pInit = NULL;
+
+   WDF_DRIVER_CONFIG_INIT(&config, WDF_NO_EVENT_CALLBACK);
+
+   config.DriverInitFlags |= WdfDriverInitNonPnpDriver;
+   config.EvtDriverUnload = EvtDriverUnload;
+
+   status = WdfDriverCreate(
+               driverObject,
+               registryPath,
+               WDF_NO_OBJECT_ATTRIBUTES,
+               &config,
+               pDriver
+               );
+
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+
+   pInit = WdfControlDeviceInitAllocate(*pDriver, &SDDL_DEVOBJ_SYS_ALL_ADM_ALL);
+   if (!pInit)
+   {
+      status = STATUS_INSUFFICIENT_RESOURCES;
+      goto Exit;
+   }
+
+   WdfDeviceInitSetDeviceType(pInit, FILE_DEVICE_NETWORK);
+   WdfDeviceInitSetCharacteristics(pInit, FILE_DEVICE_SECURE_OPEN, FALSE);
+
+   status = WdfDeviceInitAssignName(pInit, &ntDeviceName);
+   if (!NT_SUCCESS(status))
+   {
+	   goto Exit;
+   }
+
+   status = WdfDeviceCreate(&pInit, WDF_NO_OBJECT_ATTRIBUTES, pDevice);
+   if (!NT_SUCCESS(status))
+   {
+      WdfDeviceInitFree(pInit);
+      goto Exit;
+   }
+
+   status = WdfDeviceCreateSymbolicLink(*pDevice, &symbolicName);
+   if (!NT_SUCCESS(status))
+   {
+	   WdfDeviceInitFree(pInit);
+	   goto Exit;
+   }
+
+   status = DDProxyCtlDriverInit(pDevice);
+   if (!NT_SUCCESS(status))
+   {
+	   WdfDeviceInitFree(pInit);
+	   goto Exit;
+   }
+
+   WdfControlFinishInitializing(*pDevice);
+
+Exit:
+   return status;
+}
+
+
+NTSTATUS
+DriverEntry(
+   DRIVER_OBJECT* driverObject,
+   UNICODE_STRING* registryPath
+   )
+{
+   NTSTATUS status;
+   WDFDRIVER driver;
+   WDFDEVICE device;
+
+   // Request NX Non-Paged Pool when available
+   ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+
+   status = DDProxyInitDriverObjects(
+               driverObject,
+               registryPath,
+               &driver,
+               &device
+               );
+
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+
+   InitializeListHead(&gFlowList);
+   KeInitializeSpinLock(&gFlowListLock);
+
+   gWdmDevice = WdfDeviceWdmGetDeviceObject(device);
+   
+   status = DDProxyRegisterCallouts(gWdmDevice);
+
+   if (!NT_SUCCESS(status))
+   {
+      goto Exit;
+   }
+
+Exit:
+   
+   if (!NT_SUCCESS(status))
+   {
+      if (gEngineHandle != NULL)
+      {
+         DDProxyUnregisterCallouts();
+      }
+   }
+
+   return status;
+}

--- a/windows/sys/DD_proxy.c
+++ b/windows/sys/DD_proxy.c
@@ -1,0 +1,145 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved
+
+Abstract:
+
+   This file implements the classifyFn callout functions for the flow-established callouts.
+
+Environment:
+
+    Kernel mode
+
+--*/
+
+#include <ntddk.h>
+
+#pragma warning(push)
+#pragma warning(disable:4201)       // unnamed struct/union
+
+#include <fwpsk.h>
+
+#pragma warning(pop)
+
+#include <fwpmk.h>
+
+#include "DD_proxy.h"
+
+
+void
+DDProxyFlowEstablishedClassify(
+   _In_ const FWPS_INCOMING_VALUES* inFixedValues,
+   _In_ const FWPS_INCOMING_METADATA_VALUES* inMetaValues,
+   _Inout_opt_ void* layerData,
+   _In_opt_ const void* classifyContext,
+   _In_ const FWPS_FILTER* filter,
+   _In_ UINT64 flowContext,
+   _Inout_ FWPS_CLASSIFY_OUT* classifyOut
+   )
+{
+   NTSTATUS status = STATUS_SUCCESS;
+
+   BOOLEAN locked = FALSE;
+
+   KLOCK_QUEUE_HANDLE flowListLockHandle;
+
+   DD_PROXY_FLOW_INFO* flow = NULL;
+
+   UNREFERENCED_PARAMETER(layerData);
+   UNREFERENCED_PARAMETER(classifyContext);
+   UNREFERENCED_PARAMETER(flowContext);
+   UNREFERENCED_PARAMETER(filter);
+
+   flow = ExAllocatePoolWithTag(
+                        NonPagedPool,
+                        sizeof(DD_PROXY_FLOW_INFO),
+                        DD_PROXY_FLOW_CONTEXT_POOL_TAG
+                        );
+
+   if (flow == NULL)
+   {
+      status = STATUS_NO_MEMORY;
+      goto Exit;
+   }
+
+   RtlZeroMemory(flow, sizeof(DD_PROXY_FLOW_INFO));
+
+   flow->ipv4LocalAddr =
+	   RtlUlongByteSwap(
+		   inFixedValues->incomingValue\
+		   [FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_ADDRESS].value.uint32
+	   );
+
+   flow->portLocal =
+	       inFixedValues->incomingValue\
+		   [FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_PORT].value.uint16
+	   ;
+
+   flow->ipv4RemoteAddr =
+	   RtlUlongByteSwap(
+		   inFixedValues->incomingValue\
+		   [FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_ADDRESS].value.uint32
+	   );
+
+   flow->portRemote =
+		   inFixedValues->incomingValue\
+		   [FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_PORT].value.uint16
+	   ;
+
+   flow->protocol = inFixedValues->incomingValue\
+		   [FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_PROTOCOL].value.uint8;
+
+   NT_ASSERT(FWPS_IS_METADATA_FIELD_PRESENT(inMetaValues, 
+                                         FWPS_METADATA_FIELD_FLOW_HANDLE));
+   flow->flowId = inMetaValues->flowHandle;
+
+   KeAcquireInStackQueuedSpinLock(
+      &gFlowListLock,
+      &flowListLockHandle
+      );
+
+   locked = TRUE;
+
+   if (!gDriverUnloading)
+   {
+      InsertHeadList(&gFlowList, &flow->listEntry);
+   }
+   flow = NULL;
+
+   classifyOut->actionType = FWP_ACTION_PERMIT;
+
+   if (filter->flags & FWPS_FILTER_FLAG_CLEAR_ACTION_RIGHT)
+   {
+	   classifyOut->rights &= ~FWPS_RIGHT_ACTION_WRITE;
+   }
+Exit:
+
+   if(locked)
+   {
+      KeReleaseInStackQueuedSpinLock(&flowListLockHandle);
+   }
+
+   if (flow != NULL)
+   {
+      ExFreePoolWithTag(flow, DD_PROXY_FLOW_CONTEXT_POOL_TAG);
+   }
+
+   return;
+}
+
+
+NTSTATUS
+DDProxyFlowEstablishedNotify(
+   _In_ FWPS_CALLOUT_NOTIFY_TYPE notifyType,
+   _In_ const GUID* filterKey,
+   _Inout_ const FWPS_FILTER* filter
+   )
+{
+   UNREFERENCED_PARAMETER(notifyType);
+   UNREFERENCED_PARAMETER(filterKey);
+   UNREFERENCED_PARAMETER(filter);
+
+   return STATUS_SUCCESS;
+}
+
+

--- a/windows/sys/DD_proxy.h
+++ b/windows/sys/DD_proxy.h
@@ -1,0 +1,71 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved
+
+Abstract:
+
+   This header files declares common data types and function prototypes used
+   throughout the driver.
+
+Environment:
+
+    Kernel mode
+
+--*/
+
+#ifndef _DD_PROXY_H_
+#define _DD_PROXY_H_
+
+
+//
+// Pooltags used by this callout driver.
+//
+#define DD_PROXY_FLOW_CONTEXT_POOL_TAG 'olfD'
+#define DD_PROXY_CONTROL_DATA_POOL_TAG 'dcdD'
+
+extern HANDLE gInjectionHandle;
+
+extern LIST_ENTRY gFlowList;
+extern KSPIN_LOCK gFlowListLock;
+
+extern UINT32 gCalloutIdV4;
+
+extern BOOLEAN gDriverUnloading;
+
+//
+// Utility functions
+//
+
+typedef struct DD_PROXY_FLOW_INFO_
+{
+	LIST_ENTRY listEntry;
+
+	UINT32 ipv4LocalAddr;
+	UINT16 portLocal;
+	UINT32 ipv4RemoteAddr;
+	UINT16 portRemote;
+	UINT8 protocol;
+
+	UINT64 flowId;
+} DD_PROXY_FLOW_INFO;
+
+
+void
+DDProxyFlowEstablishedClassify(
+   _In_ const FWPS_INCOMING_VALUES* inFixedValues,
+   _In_ const FWPS_INCOMING_METADATA_VALUES* inMetaValues,
+   _Inout_opt_ void* layerData,
+   _In_opt_ const void* classifyContext,
+   _In_ const FWPS_FILTER* filter,
+   _In_ UINT64 flowContext,
+   _Inout_ FWPS_CLASSIFY_OUT* classifyOut
+   );
+
+NTSTATUS
+DDProxyFlowEstablishedNotify(
+   _In_ FWPS_CALLOUT_NOTIFY_TYPE notifyType,
+   _In_ const GUID* filterKey,
+   _Inout_ const FWPS_FILTER* filter
+   );
+
+#endif // _DD_PROXY_H_

--- a/windows/sys/ddproxy.inf
+++ b/windows/sys/ddproxy.inf
@@ -1,0 +1,63 @@
+;;;
+;;; Copyright (c) Microsoft Corporation. All rights reserved
+;;;
+;;; Abstract:
+;;; DatagramData Proxy Callout sample driver install configuration.
+;;;
+
+[Version]
+    Signature   = "$Windows NT$"
+    Class       = WFPCALLOUTS
+    ClassGuid   = {57465043-616C-6C6F-7574-5F636C617373}
+    Provider    = %ProviderString%
+    CatalogFile = DDProxy.cat
+    DriverVer   = 11/24/2014,14.24.55.836
+
+[SourceDisksNames]
+   1 = %DDProxyDisk%,,,""
+
+[SourceDisksFiles]
+   DDProxy.sys = 1,,
+
+[DestinationDirs]
+    DefaultDestDir      = 12                                               ; %WinDir%\System32\Drivers
+    DDProxy.DriverFiles = 12                                               ; %WinDir%\System32\Drivers
+
+[DefaultInstall]
+    OptionDesc = %DDProxyServiceDesc%
+    CopyFiles  = DDProxy.DriverFiles
+
+[DefaultInstall.Services]
+    AddService = %DDProxyServiceName%,,DDProxy.Service
+
+[DefaultUninstall]
+    DelFiles = DDProxy.DriverFiles
+
+[DefaultUninstall.Services]
+    DelService = %DDProxyServiceName%,0x200                                ; SPSVCINST_STOPSERVICE
+    DelReg     = DDProxy.DelRegistry
+
+[DDProxy.DriverFiles]
+    DDProxy.sys,,,0x00000040                                               ; COPYFLG_OVERWRITE_OLDER_ONLY
+
+[DDProxy.Service]
+    DisplayName   = %DDProxyServiceName%
+    Description   = %DDProxyServiceDesc%
+    ServiceType   = 1                                                      ; SERVICE_KERNEL_DRIVER
+    StartType     = 3                                                      ; SERVICE_DEMAND_START
+    ErrorControl  = 1                                                      ; SERVICE_ERROR_NORMAL
+    ServiceBinary = %12%\DDProxy.sys                                       ; %WinDir%\System32\Drivers\DDProxy.sys
+    AddReg        = DDProxy.AddRegistry
+
+[DDProxy.AddRegistry]
+    HKR,"Parameters","DestinationAddressToIntercept",0x00000000,"10.0.0.1" ; FLG_ADDREG_TYPE_SZ
+    HKR,"Parameters","NewDestinationAddress",0x00000000,"10.0.0.2"         ; FLG_ADDREG_TYPE_SZ
+
+[DDProxy.DelRegistry]
+    HKR,"Parameters",,,
+
+[Strings]
+    ProviderString     = "TODO-Set-Provider"
+    DDProxyDisk        = "DatagramData Proxy Installation Disk"
+    DDProxyServiceDesc = "DatagramData Proxy Callout Driver"
+    DDProxyServiceName = "DDProxy"

--- a/windows/sys/ddproxy.vcxproj
+++ b/windows/sys/ddproxy.vcxproj
@@ -1,0 +1,184 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FEABD37B-18D6-4A7B-9AD2-F5A65A904A57}</ProjectGuid>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <KMDF_VERSION_MAJOR>1</KMDF_VERSION_MAJOR>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <SampleGuid>{6462DC10-B4DC-441C-8A08-D8E436A4566C}</SampleGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>$(IntDir)</OutDir>
+  </PropertyGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ItemGroup Label="WrappedTaskItems" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>ddproxy</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>ddproxy</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>ddproxy</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>ddproxy</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH;..\inc)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\inc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;NDIS_SUPPORT_NDIS6;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\ndis.lib;$(DDK_LIB_PATH)\wdmsec.lib;$(DDK_LIB_PATH)\fwpkclnt.lib;$(SDK_LIB_PATH)\uuid.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dd_drv.c" />
+    <ClCompile Include="dd_proxy.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Exclude="@(Inf)" Include="*.inf" />
+    <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
+    <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
+    <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/windows/sys/ddproxy.vcxproj.Filters
+++ b/windows/sys/ddproxy.vcxproj.Filters
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx;*</Extensions>
+      <UniqueIdentifier>{BFAC6914-B9A3-4F2B-BFE9-BFC27304CA74}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+      <UniqueIdentifier>{8FB969E4-D27A-4B85-832B-EACA8E280317}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms;man;xml</Extensions>
+      <UniqueIdentifier>{293AD434-85E8-431D-9C4A-989DBCE5D623}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Driver Files">
+      <Extensions>inf;inv;inx;mof;mc;</Extensions>
+      <UniqueIdentifier>{9B57B05B-FB4B-4582-8F2B-E95E2F7CD3E3}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dd_drv.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="dd_proxy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Code based on ddproxy driver sample from WDK. Needs a lot of cleanup but demonstrates how to write a simple WFP callout function. The IOCTL handler code is really hacky since I am not really familiar with the WDF APIs used in the sample - perhaps the driver code can be simply switched to use the native WDM APIs. File, function and device names should also be changed to suit future purpose.

To build: use msbuild in Visual Studio environment targetting release/x64.
To install: right-click install with inf-file or manually create reg entries for service and copy sys file to system32/drivers.

